### PR TITLE
Fix crash on android o when receiving a notification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         butterknife_version = '8.0.1'
         room_version = '1.0.0-beta2'
         support_library_version = '26.1.0'
-        firebase_version = '10.2.1'
+        firebase_version = '11.4.2'
         glide_version = '4.2.0'
     }
     repositories {


### PR DESCRIPTION
There is an issue related to Android O and the usage of Firebase for push notifications we should fix by updating the firebase version.

Here you have some info:

* [Crashlytics error](https://www.fabric.io/emagina-labs/android/apps/com.emaginalabs.haveaniceday/issues/59ea3dc461b02d480de9ac21?time=last-twenty-four-hours)
* [Firebase for android releases page](https://firebase.google.com/support/release-notes/android)

The bug seems related to Android Oreo background services usage where we should initialize a service as a foreground service. I've reviewed the code and we don't start the service manually so I assume this has been fixed by the firebase team. I couldn't try if this is working and I have to leave but let me know if I can help to fix this issue.