### PR TITLE
Treat the case when the photo_url can not be downloaded

### DIFF
--- a/mobile/src/main/kotlin/com/emaginalabs/haveaniceday/app/notification/HappyNotificationMessagingService.kt
+++ b/mobile/src/main/kotlin/com/emaginalabs/haveaniceday/app/notification/HappyNotificationMessagingService.kt
@@ -5,6 +5,8 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.drawable.Drawable
 import android.support.v4.app.NotificationCompat
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.SimpleTarget
@@ -83,11 +85,12 @@ class HappyNotificationMessagingService : FirebaseMessagingService(), LazyKodein
                         .load(notification.photoUrl)
                         .into(object : SimpleTarget<Bitmap>() {
                             override fun onResourceReady(resource: Bitmap?, transition: Transition<in Bitmap>?) {
-                                val bigPictureStyle = NotificationCompat.BigPictureStyle()
-                                        .bigPicture(resource)
-                                        .setSummaryText(notification.message)
-                                notificationBuilder.setStyle(bigPictureStyle)
-                                notificationManager.notify(notificationId, notificationBuilder.build())
+                                notifyWithImage(resource, notification, notificationBuilder, notificationManager, notificationId)
+                            }
+
+                            override fun onLoadFailed(errorDrawable: Drawable?) {
+                                val picture = BitmapFactory.decodeResource(resources, R.mipmap.happy_loader)
+                                notifyWithImage(picture, notification, notificationBuilder, notificationManager, notificationId)
                             }
                         })
             }
@@ -95,6 +98,19 @@ class HappyNotificationMessagingService : FirebaseMessagingService(), LazyKodein
             notificationManager.notify(notificationId, notificationBuilder.build())
         }
 
+    }
+
+    private fun notifyWithImage(
+            picture: Bitmap?,
+            notification: Notification,
+            notificationBuilder: NotificationCompat.Builder,
+            notificationManager: NotificationManager,
+            notificationId: Int) {
+        val bigPictureStyle = NotificationCompat.BigPictureStyle()
+                .bigPicture(picture)
+                .setSummaryText(notification.message)
+        notificationBuilder.setStyle(bigPictureStyle)
+        notificationManager.notify(notificationId, notificationBuilder.build())
     }
 
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** NA
* **Related pull-requests:** NA

### :tophat: What is the goal?

Sometimes the received image can't be downloaded when the phone receives the notification. In this case the notification won't be displayed.
Once this PR is merged the notification will be shown but with a default happy image :).

### How is it being implemented?

Just implement `onLoadFailed` 

### How can it be tested?
1. [x] Happy path: send a message with a valid image and the notification will be shown in the notification center
2. [x] Invalid image: send a message with an empty image or invalid one and the notification will be shown in the notification center with a default image.
